### PR TITLE
Grid column movable off by default

### DIFF
--- a/demos/app/grid/sample.component.html
+++ b/demos/app/grid/sample.component.html
@@ -63,6 +63,7 @@
             <igx-switch [(ngModel)]="col.sortable">Sorting</igx-switch>
             <igx-switch [(ngModel)]="col.editable">Editable</igx-switch>
             <igx-switch [(ngModel)]="col.hidden">Visible</igx-switch>
+            <igx-switch [(ngModel)]="col.movable">Movable</igx-switch>
         </div>
     </div>
 
@@ -106,7 +107,7 @@
     <igx-grid #grid3 [data]="remote | async" [paging]="true" [perPage]="10"
         (onPagingDone)="process($event)" (onSortingDone)="process($event)" (onBeforeProcess)="onProcess($event)">
         <igx-column [sortable]="true" [field]="'ProductID'" [header]="'ID'"></igx-column>
-        <igx-column [editable]="true" [filtering]="true" [field]="'ProductName'"></igx-column>
+        <igx-column [sortable]="true" [field]="'ProductName'"></igx-column>
         <igx-column [sortable]="true" [field]="'UnitsInStock'" [header]="'In Stock'"></igx-column>
         <igx-column [field]="'Discontinued'" [sortable]="true">
             <template igxHeader let-column="column">
@@ -123,6 +124,6 @@
 <div style="width: 100%; display: flex; position: fixed; bottom: 0; justify-content: center">
     <igx-snackbar #snax [autoHide]="true" displayTime="2500"
         style="width: 50%;"
-        message="Row was deleted" actionText="Undo" (onAction)="restore()">
+        actionText="Undo" (onAction)="restore()">
     </igx-snackbar>
 <div>

--- a/demos/app/grid/sample.component.ts
+++ b/demos/app/grid/sample.component.ts
@@ -1,9 +1,9 @@
-import { IgxColumnComponent } from '../../../src/grid/column.component';
+import { IgxColumnComponent } from "../../../src/grid/column.component";
 import { Http } from "@angular/http";
 import { Component, Injectable, ViewChild } from "@angular/core";
 import { BehaviorSubject, Observable } from "rxjs/Rx";
 
-import { IgxGridBindingBehavior, IgxGridColumnInitEvent, IgxGridComponent } from '../../../src/grid/grid.component';
+import { IgxGridBindingBehavior, IgxGridColumnInitEvent, IgxGridComponent } from "../../../src/grid/grid.component";
 import {
     DataContainer,
     DataState,
@@ -13,7 +13,7 @@ import {
     PagingState,
     SortingDirection,
     StableSortingStrategy
-} from '../../../src/main';
+} from "../../../src/main";
 
 
 @Injectable()
@@ -105,7 +105,7 @@ export class RemoteService {
     moduleId: module.id,
     selector: "grid-sample",
     templateUrl: "sample.component.html",
-    styleUrls: ['sample.component.css']
+    styleUrls: ["sample.component.css"]
 })
 export class GridSampleComponent {
     constructor(private localService: LocalService,
@@ -146,7 +146,7 @@ export class GridSampleComponent {
       this.grid3.state = {
         paging: {
           index: 2,
-          recordsPerPage: 15
+          recordsPerPage: 10
         },
         sorting: {
           expressions: [
@@ -242,11 +242,15 @@ export class GridSampleComponent {
       this.selectedRow = Object.assign({}, this.grid1.getRow(this.selectedCell.rowIndex));
       this.grid1.deleteRow(this.selectedCell.rowIndex);
       this.selectedCell = {};
-      this.snax.show();
+      this.snax.message = `Row with ID ${this.selectedRow.record.ID} was deleted`;
+      this.snax.isVisible = true;
+      // this.snax.show();
     }
 
     restore() {
       this.grid1.addRow(this.selectedRow.record, this.selectedRow.index);
-      this.snax.hide();
+      this.snax.isVisible = false;
+      // this.snax.hide();
+
     }
 }

--- a/demos/app/grid/sample.component.ts
+++ b/demos/app/grid/sample.component.ts
@@ -243,14 +243,11 @@ export class GridSampleComponent {
       this.grid1.deleteRow(this.selectedCell.rowIndex);
       this.selectedCell = {};
       this.snax.message = `Row with ID ${this.selectedRow.record.ID} was deleted`;
-      this.snax.isVisible = true;
-      // this.snax.show();
+      this.snax.show();
     }
 
     restore() {
       this.grid1.addRow(this.selectedRow.record, this.selectedRow.index);
-      this.snax.isVisible = false;
-      // this.snax.hide();
-
+      this.snax.hide();
     }
 }

--- a/src/grid/column.component.ts
+++ b/src/grid/column.component.ts
@@ -20,6 +20,7 @@ export class IgxColumnComponent implements AfterContentInit {
     @Input() public editable: boolean = false;
     @Input() public filtering: boolean = false;
     @Input() public hidden: boolean = false;
+    @Input() public movable: boolean = false;
     @Input() public width: string;
     @Input() public index: number;
     @Input() public filteringCondition: Function = FilteringCondition.string.contains;

--- a/src/grid/grid.component.html
+++ b/src/grid/grid.component.html
@@ -7,9 +7,6 @@
                     role="columnheader" tabindex="0"
                     class="igx-grid__th"
                     [attr.aria-label]="col.header || col.field"
-                    (onDrop)="moveColumn($event)"
-                    [igxDraggable]="col.index"
-                    [igxDroppable]="col.index"
                     [igxColumnSorting]="col"
                     [sortDirection]="getSortedExpression(col)"
                     [style.width]="col.width || ''">
@@ -24,6 +21,9 @@
                             [value]="filteringExpressions[col.field]?.searchVal || ''"
                             [column]="col">
                         </igx-col-filter>
+                        <div *ngIf="col.movable" (onDrop)="moveColumn($event)" [igxDraggable]="col.index" [igxDroppable]="col.index">
+                            <igx-icon name="swap_horiz"></igx-icon>
+                        </div>
                     </div>
                 </th>
             </template>

--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -46,11 +46,12 @@ import { IgxPaginatorComponent, IgxPaginatorEvent } from "./paginator.component"
 import {
     DataContainer,
     DataState,
-    PagingState,
     FilteringExpression,
     IgxDialog,
     IgxDialogModule,
     IgxDirectivesModule,
+    IgxIconModule,
+    PagingState,
     SortingDirection,
     SortingExpression
 } from "../../src/main";
@@ -663,6 +664,6 @@ let GRID_DIRECTIVES: any[] = [
     declarations: GRID_DIRECTIVES,
     entryComponents: [IgxColumnComponent],
     exports: GRID_DIRECTIVES,
-    imports: [CommonModule, IgxDialogModule, IgxDirectivesModule, FormsModule],
+    imports: [CommonModule, IgxIconModule, IgxDialogModule, IgxDirectivesModule, FormsModule],
 })
 export class IgxGridModule {}


### PR DESCRIPTION
The columns now are not movable by default but instead controlled through the column `movable` property.
Fixed a few small issues with the grid sample.

