### PR TITLE
(FIX) Cast block reference to string before using it in children scopes

### DIFF
--- a/src/themes/material/extends/_buttons.scss
+++ b/src/themes/material/extends/_buttons.scss
@@ -62,7 +62,7 @@
 }
 
 %igx-button--round {
-    $block: &;
+    $block: bem--selector-to-string(&);
     
     position: relative;
     display: flex;

--- a/src/themes/material/modules/_controls.scss
+++ b/src/themes/material/modules/_controls.scss
@@ -1,7 +1,7 @@
 @include b(igx-control) {
     // Save the reference to this block element
     // in a variable for scoped access
-    $block: &;
+    $block: bem--selector-to-string(&);
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/themes/material/modules/_inputs.scss
+++ b/src/themes/material/modules/_inputs.scss
@@ -6,7 +6,7 @@ input:-webkit-autofill {
 }
 
 @include b(igx-form-group) {
-	$block: &;
+	$block: bem--selector-to-string(&);
 
 	@extend %igx-input-display;
 


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:

