### PR TITLE
Adding grid scenarios (sorting and filtering)

### DIFF
--- a/src/grid/grid.component.spec.ts
+++ b/src/grid/grid.component.spec.ts
@@ -1,10 +1,11 @@
 import { Component, ViewChild } from "@angular/core";
 import { async, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { IgxGridComponent, IgxGridModule, IgxGridRow } from "./grid.component";
-import { CustomJobTitleSortingStrategy, CustomDateRangeFilteringStrategy, CustomStrategyData } from "../grid/tests.helper"
 import { FilteringCondition } from "../../src/data-operations/filtering-condition";
 import { IDataState } from "../data-operations/data-state.interface";
+import { CustomDateRangeFilteringStrategy, CustomJobTitleSortingStrategy } from "../grid/tests.helper";
+import { CustomStrategyData } from "../grid/tests.helper";
+import { IgxGridComponent, IgxGridModule, IgxGridRow } from "./grid.component";
 
 describe("IgxGrid", () => {
 
@@ -742,17 +743,21 @@ describe("IgxGrid", () => {
         const gridElement: HTMLElement = fixture.nativeElement.querySelector("table");
         const jobTitleColumn = gridElement.querySelector("thead > tr > th:nth-child(3)");
 
-        jobTitleColumn.dispatchEvent(new Event('click'));
+        jobTitleColumn.dispatchEvent(new Event("click"));
         fixture.detectChanges();
 
-        expect(jobTitleColumn.classList.contains("asc")).toBe(false, "Column should not be sorted by job title starting from CEO");
+        expect(jobTitleColumn
+            .classList.contains("asc"))
+            .toBe(false, "Column should not be sorted by job title starting from CEO");
         grid.getColumnByField("JobTitle").sortable = true;
         fixture.detectChanges();
 
         jobTitleColumn.dispatchEvent(new Event("click"));
         fixture.detectChanges();
 
-        expect(jobTitleColumn.classList.contains("asc")).toBe(true, "Column should be sorted by job title starting from CEO");
+        expect(jobTitleColumn
+            .classList.contains("asc"))
+            .toBe(true, "Column should be sorted by job title starting from CEO");
 
         expect(grid.getRow(0).cells[0].dataItem).toMatch("6");
         expect(grid.getRow(0).cells[1].dataItem).toMatch("Erma Walsh");
@@ -776,7 +781,7 @@ describe("IgxGrid", () => {
         const grid = fixture.componentInstance.grid;
         const data = fixture.componentInstance.data;
         const gridElement: HTMLElement = fixture.nativeElement.querySelector("table");
-        const tbody: HTMLElement = fixture.nativeElement.querySelector("table > tbody")
+        const tbody: HTMLElement = fixture.nativeElement.querySelector("table > tbody");
 
         grid.getColumnByField("HireDate").filtering = true;
         // This FilteringCondition is going to be used as 'between'
@@ -789,7 +794,7 @@ describe("IgxGrid", () => {
         expect(grid.getRow(0).cells[1].dataItem).toMatch("Casey Houston");
 
         // Between dates
-        let betweenDates = {
+        const betweenDates = {
             Date1: "2006-12-18T11:23:17.714Z",
             Date2: "2010-11-20T10:14:12.714Z"
         };
@@ -910,7 +915,6 @@ export class IgxGridCustomSortingTestComponent {
     }
 }
 
-
 @Component({
     template: `<igx-grid [data]="data">
         <igx-column [field]="'ID'" [header]="'ID'"></igx-column>
@@ -931,11 +935,11 @@ export class IgxGridCustomFilteringDateRange {
     @ViewChild(IgxGridComponent) public grid: IgxGridComponent;
 
     public ngOnInit(): void {
-        this.grid.state = <IDataState>{
+        this.grid.state = {
             filtering: {
                 expressions: [],
                 strategy: new CustomDateRangeFilteringStrategy()
             }
-        }
+        };
     }
 }

--- a/src/grid/grid.component.spec.ts
+++ b/src/grid/grid.component.spec.ts
@@ -3,8 +3,9 @@ import { async, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { FilteringCondition } from "../data-operations/filtering-condition";
 import { IgxGridComponent, IgxGridModule, IgxGridRow } from "./grid.component";
+import { CustomJobTitleSortingStrategy } from "../grid/tests.helper"
 
-describe("IgxGrid", () => {
+fdescribe("IgxGrid", () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -12,11 +13,12 @@ describe("IgxGrid", () => {
                 IgxGridMarkupDefinitionTestComponent,
                 IgxGridngForDefinitionTestComponent,
                 IgxGridTemplatedTestComponent,
-                IgxGridWithAutogenerateTestComponent
+                IgxGridWithAutogenerateTestComponent,
+                IgxGridCustomSortingTestComponent
             ],
             imports: [BrowserAnimationsModule, IgxGridModule]
         })
-        .compileComponents();
+            .compileComponents();
     }));
 
     it("should initialize a grid with columns from markup", () => {
@@ -173,7 +175,7 @@ describe("IgxGrid", () => {
 
         fixture.detectChanges();
 
-        const newRow = {ID: 4, Name: "Test String"};
+        const newRow = { ID: 4, Name: "Test String" };
 
         // Row Adding
         grid.addRow(newRow);
@@ -233,7 +235,7 @@ describe("IgxGrid", () => {
 
         // Row updating through API
         spyOn(grid.onEditDone, "emit");
-        grid.updateRow(3, {ID: 10, Name: "New Value"});
+        grid.updateRow(3, { ID: 10, Name: "New Value" });
         fixture.detectChanges();
 
         expect(grid.onEditDone.emit).toHaveBeenCalled();
@@ -345,25 +347,25 @@ describe("IgxGrid", () => {
         fixture.detectChanges();
         expect(document.activeElement).toBe(cells[0]);
 
-        let args: KeyboardEventInit = {key: "ArrowRight", bubbles: true};
+        let args: KeyboardEventInit = { key: "ArrowRight", bubbles: true };
         cells[0].dispatchEvent(new KeyboardEvent("keydown", args));
         tick();
         fixture.detectChanges();
         expect(document.activeElement).toBe(cells[1]);
 
-        args = {key: "ArrowLeft", bubbles: true};
+        args = { key: "ArrowLeft", bubbles: true };
         cells[1].dispatchEvent(new KeyboardEvent("keydown", args));
         tick();
         fixture.detectChanges();
         expect(document.activeElement).toBe(cells[0]);
 
-        args = {key: "ArrowDown", bubbles: true};
+        args = { key: "ArrowDown", bubbles: true };
         cells[0].dispatchEvent(new KeyboardEvent("keydown", args));
         tick();
         fixture.detectChanges();
         expect(document.activeElement).toBe(cells[2]);
 
-        args = {key: "ArrowUp", bubbles: true};
+        args = { key: "ArrowUp", bubbles: true };
         cells[2].dispatchEvent(new KeyboardEvent("keydown", args));
         tick();
         fixture.detectChanges();
@@ -416,7 +418,7 @@ describe("IgxGrid", () => {
         fixture.detectChanges();
 
         const filterInputButton: HTMLElement = fixture.nativeElement
-                                                .querySelector(".igx-filtering__toggle > .toggle-icon");
+            .querySelector(".igx-filtering__toggle > .toggle-icon");
         const tbody: HTMLElement = fixture.nativeElement.querySelector("table > tbody");
 
         expect(filterInputButton).toBeTruthy();
@@ -456,7 +458,7 @@ describe("IgxGrid", () => {
         tick();
         fixture.detectChanges();
 
-        let args: KeyboardEventInit = {key: "Enter", bubbles: true};
+        let args: KeyboardEventInit = { key: "Enter", bubbles: true };
         gridElement.querySelector("tbody td:first-child")
             .dispatchEvent(new KeyboardEvent("keyup", args));
 
@@ -479,7 +481,7 @@ describe("IgxGrid", () => {
         tick();
         fixture.detectChanges();
 
-        args = {key: "Enter", bubbles: true};
+        args = { key: "Enter", bubbles: true };
         dialog.dispatchEvent(new KeyboardEvent("keyup", args));
 
         tick();
@@ -507,7 +509,7 @@ describe("IgxGrid", () => {
         tick();
         fixture.detectChanges();
 
-        let args: KeyboardEventInit = {key: "Enter", bubbles: true};
+        let args: KeyboardEventInit = { key: "Enter", bubbles: true };
         gridElement.querySelector("tbody td:first-child")
             .dispatchEvent(new KeyboardEvent("keyup", args));
 
@@ -530,7 +532,7 @@ describe("IgxGrid", () => {
         tick();
         fixture.detectChanges();
 
-        args = {key: "Escape", bubbles: true};
+        args = { key: "Escape", bubbles: true };
         dialog.dispatchEvent(new KeyboardEvent("keyup", args));
 
         tick();
@@ -624,7 +626,7 @@ describe("IgxGrid", () => {
         expect(gridElement.querySelector(".igx-paginator > span").textContent).toMatch("2 of 3");
         expect(gridElement.querySelector("tbody > tr > td").textContent).toMatch("2");
 
-        let args: KeyboardEventInit = {key: "Enter", bubbles: true};
+        let args: KeyboardEventInit = { key: "Enter", bubbles: true };
         gridElement.querySelector("tbody > tr > td")
             .dispatchEvent(new KeyboardEvent("keyup", args));
 
@@ -647,7 +649,7 @@ describe("IgxGrid", () => {
         tick();
         fixture.detectChanges();
 
-        args = {key: "Enter", bubbles: true};
+        args = { key: "Enter", bubbles: true };
         dialog.dispatchEvent(new KeyboardEvent("keyup", args));
 
         tick();
@@ -691,7 +693,7 @@ describe("IgxGrid", () => {
         expect(gridElement.querySelector(".igx-paginator > span").textContent).toMatch("2 of 3");
         expect(gridElement.querySelector("tbody > tr > td").textContent).toMatch("2");
 
-        let args: KeyboardEventInit = {key: "Enter", bubbles: true};
+        let args: KeyboardEventInit = { key: "Enter", bubbles: true };
         gridElement.querySelector("tbody > tr > td")
             .dispatchEvent(new KeyboardEvent("keyup", args));
 
@@ -714,7 +716,7 @@ describe("IgxGrid", () => {
         tick();
         fixture.detectChanges();
 
-        args = {key: "Escape", bubbles: true};
+        args = { key: "Escape", bubbles: true };
         dialog.dispatchEvent(new KeyboardEvent("keyup", args));
 
         tick();
@@ -727,6 +729,43 @@ describe("IgxGrid", () => {
 
         expect(gridElement.querySelector("tbody > tr > td").textContent).toMatch("2");
         expect(data[1].ID).toMatch("2");
+    }));
+
+    fit("custom sorting (job title)", fakeAsync(() => {
+        const fixture = TestBed.createComponent(IgxGridCustomSortingTestComponent);
+        fixture.detectChanges();
+
+        const grid = fixture.componentInstance.grid;
+        const data = fixture.componentInstance.data;
+        const gridElement: HTMLElement = fixture.nativeElement.querySelector("table");
+        const jobTitleColumn = gridElement.querySelector("thead > tr > th:nth-child(3)");
+
+        jobTitleColumn.dispatchEvent(new Event('click'));
+        fixture.detectChanges();
+
+        expect(jobTitleColumn.classList.contains("asc")).toBe(false, "Column should not be sorted by job title starting from CEO");
+        grid.getColumnByField("JobTitle").sortable = true;
+        fixture.detectChanges();
+
+        jobTitleColumn.dispatchEvent(new Event("click"));
+        fixture.detectChanges();
+
+        expect(jobTitleColumn.classList.contains("asc")).toBe(true, "Column should be sorted by job title starting from CEO");
+
+        expect(grid.getRow(0).cells[0].dataItem).toMatch("6");
+        expect(grid.getRow(0).cells[1].dataItem).toMatch("Erma Walsh");
+        expect(grid.getRow(0).cells[2].dataItem).toMatch("CEO");
+
+        expect(grid.getCell(1, "ID").dataItem).toMatch("1");
+        expect(grid.getCell(2, "ID").dataItem).toMatch("2");
+        expect(grid.getCell(3, "ID").dataItem).toMatch("3");
+        expect(grid.getCell(4, "ID").dataItem).toMatch("10");
+        expect(grid.getCell(5, "ID").dataItem).toMatch("8");
+        expect(grid.getCell(6, "ID").dataItem).toMatch("5");
+        expect(grid.getCell(7, "ID").dataItem).toMatch("4");
+        expect(grid.getCell(8, "ID").dataItem).toMatch("7");
+        expect(grid.getCell(9, "ID").dataItem).toMatch("9");
+
     }));
 });
 
@@ -741,9 +780,9 @@ describe("IgxGrid", () => {
 export class IgxGridMarkupDefinitionTestComponent {
 
     public data = [
-        {ID: 1, Name: "Johny"},
-        {ID: 2, Name: "Sally"},
-        {ID: 3, Name: "Tim"}
+        { ID: 1, Name: "Johny" },
+        { ID: 2, Name: "Sally" },
+        { ID: 3, Name: "Tim" }
     ];
 
     @ViewChild(IgxGridComponent) public grid: IgxGridComponent;
@@ -760,9 +799,9 @@ export class IgxGridMarkupDefinitionTestComponent {
 export class IgxGridngForDefinitionTestComponent {
 
     public data = [
-        {ID: 1, Name: "Johny"},
-        {ID: 2, Name: "Sally"},
-        {ID: 3, Name: "Tim"}
+        { ID: 1, Name: "Johny" },
+        { ID: 2, Name: "Sally" },
+        { ID: 3, Name: "Tim" }
     ];
 
     @ViewChild(IgxGridComponent) public grid: IgxGridComponent;
@@ -786,9 +825,9 @@ export class IgxGridngForDefinitionTestComponent {
 export class IgxGridTemplatedTestComponent {
 
     public data = [
-        {ID: 1, Name: "Johny"},
-        {ID: 2, Name: "Sally"},
-        {ID: 3, Name: "Tim"}
+        { ID: 1, Name: "Johny" },
+        { ID: 2, Name: "Sally" },
+        { ID: 3, Name: "Tim" }
     ];
 
     @ViewChild(IgxGridComponent) public grid: IgxGridComponent;
@@ -802,10 +841,47 @@ export class IgxGridTemplatedTestComponent {
 export class IgxGridWithAutogenerateTestComponent {
 
     public data = [
-        {ID: 1, Name: "Johny"},
-        {ID: 2, Name: "Sally"},
-        {ID: 3, Name: "Tim"}
+        { ID: 1, Name: "Johny" },
+        { ID: 2, Name: "Sally" },
+        { ID: 3, Name: "Tim" }
     ];
 
     @ViewChild(IgxGridComponent) public grid: IgxGridComponent;
 }
+
+@Component({
+    template: `
+    <igx-grid [data]="data" >
+        <igx-column [field]="'ID'" [header]="'ID'"></igx-column>
+        <igx-column [field]="'Name'" [header]="'Name'"></igx-column>
+        <igx-column [field]="'JobTitle'" [header]="'JobTitle'"></igx-column>
+    </igx-grid>
+    `
+})
+export class IgxGridCustomSortingTestComponent {
+    public data = [
+        { ID: 1, Name: "Casey Houston", JobTitle: "Vice President", },
+        { ID: 2, Name: "Gilberto Todd", JobTitle: "Director" },
+        { ID: 3, Name: "Tanya Bennett", JobTitle: "Director" },
+        { ID: 4, Name: "Jack Simon", JobTitle: "Software Developer" },
+        { ID: 5, Name: "Celia Martinez", JobTitle: "Senior Software Developer" },
+        { ID: 6, Name: "Erma Walsh", JobTitle: "CEO" },
+        { ID: 7, Name: "Debra Morton", JobTitle: "Associate Software Developer" },
+        { ID: 8, Name: "Erika Wells", JobTitle: "Software Development Team Lead" },
+        { ID: 9, Name: "Leslie Hansen", JobTitle: "Associate Software Developer" },
+        { ID: 10, Name: "Eduardo Ramirez", JobTitle: "Manager" }
+    ];
+
+    @ViewChild(IgxGridComponent) public grid: IgxGridComponent;
+
+    public ngOnInit(): void {
+        this.grid.state = {
+            sorting: {
+                expressions: [],
+                strategy: new CustomJobTitleSortingStrategy()
+            }
+        };
+    }
+}
+
+

--- a/src/grid/grid.component.spec.ts
+++ b/src/grid/grid.component.spec.ts
@@ -6,7 +6,7 @@ import { CustomJobTitleSortingStrategy, CustomDateRangeFilteringStrategy, Custom
 import { FilteringCondition } from "../../src/data-operations/filtering-condition";
 import { IDataState } from "../data-operations/data-state.interface";
 
-fdescribe("IgxGrid", () => {
+describe("IgxGrid", () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({

--- a/src/grid/tests.helper.ts
+++ b/src/grid/tests.helper.ts
@@ -1,5 +1,9 @@
 import { SortingStrategy } from "../../src/data-operations/sorting-strategy"
 import { StableSortingStrategy } from "../../src/data-operations/stable-sorting-strategy"
+import { IFilteringStrategy, FilteringStrategy } from "../../src/data-operations/filtering-strategy"
+import { FilteringCondition } from "../../src/data-operations/filtering-condition";
+import { FilteringLogic, IFilteringExpression } from "../../src/data-operations/filtering-expression.interface";
+import { IFilteringState } from "../../src/data-operations/filtering-state.interface";
 
 const KEY_JOB_TITLE: String =  "JobTitle";
 
@@ -69,4 +73,82 @@ export class CustomJobTitleSortingStrategy extends SortingStrategy {
         }
         return res;
     }
+}
+
+
+export class CustomDateRangeFilteringStrategy implements IFilteringStrategy {
+    public filter<T>(data: T[],
+                     expressions: IFilteringExpression[],
+                     logic?: FilteringLogic): T[] {
+        let i;
+        let rec;
+        const len = data.length;
+        const res: T[] = [];
+        if (!expressions || !expressions.length || !len) {
+            return data;
+        }
+        for (i = 0; i < len; i++) {
+            rec = data[i];
+            if (this.matchRecordByExpressions(rec, expressions, i, logic)) {
+                res.push(rec);
+            }
+        }
+        return res;
+    }
+    public findMatch(rec: object, expr: IFilteringExpression, index: number): boolean {
+        const cond = expr.condition;
+        const val = rec[expr.fieldName];
+        var searchVal = "";
+
+        try {
+            searchVal = JSON.parse(expr.searchVal);
+        } catch (e) {
+            searchVal = expr.searchVal;
+        }
+
+        if (typeof(searchVal) === "object" && Object.keys(searchVal).length === 2) {
+            return (new Date(val) > new Date(searchVal[Object.keys(searchVal)[0]])) &&
+                (new Date(val) < new Date(searchVal[Object.keys(searchVal)[1]]))
+        }
+        else{
+            return cond(new Date(val), new Date(searchVal));
+        }
+    }
+    public matchRecordByExpressions(rec: object,
+                                    expressions: IFilteringExpression[],
+                                    index: number,
+                                    logic?: FilteringLogic): boolean {
+        let i;
+        let match = false;
+        const and = (logic === FilteringLogic.And);
+        const len = expressions.length;
+        for (i = 0; i < len; i++) {
+            match = this.findMatch(rec, expressions[i], i);
+            if (and) {
+                if (!match) {
+                    return false;
+                }
+            } else {
+                if (match) {
+                    return true;
+                }
+            }
+        }
+        return match;
+    }
+}
+
+export class CustomStrategyData{
+    public data = [
+        { ID: 1, Name: "Casey Houston", JobTitle: "Vice President", HireDate: "2017-06-19T11:43:07.714Z" },
+        { ID: 2, Name: "Gilberto Todd", JobTitle: "Director", HireDate: "2015-12-18T11:23:17.714Z" },
+        { ID: 3, Name: "Tanya Bennett", JobTitle: "Director", HireDate: "2005-11-18T11:23:17.714Z" },
+        { ID: 4, Name: "Jack Simon", JobTitle: "Software Developer", HireDate: "2008-12-18T11:23:17.714Z" },
+        { ID: 5, Name: "Celia Martinez", JobTitle: "Senior Software Developer", HireDate: "2007-12-19T11:23:17.714Z" },
+        { ID: 6, Name: "Erma Walsh", JobTitle: "CEO", HireDate: "2016-12-18T11:23:17.714Z" },
+        { ID: 7, Name: "Debra Morton", JobTitle: "Associate Software Developer", HireDate: "2005-11-19T11:23:17.714Z" },
+        { ID: 8, Name: "Erika Wells", JobTitle: "Software Development Team Lead", HireDate: "2005-10-14T11:23:17.714Z" },
+        { ID: 9, Name: "Leslie Hansen", JobTitle: "Associate Software Developer", HireDate: "2013-10-10T11:23:17.714Z" },
+        { ID: 10, Name: "Eduardo Ramirez", JobTitle: "Manager", HireDate: "2011-11-28T11:23:17.714Z" }
+    ];
 }

--- a/src/grid/tests.helper.ts
+++ b/src/grid/tests.helper.ts
@@ -1,26 +1,46 @@
-import { SortingStrategy } from "../../src/data-operations/sorting-strategy"
-import { StableSortingStrategy } from "../../src/data-operations/stable-sorting-strategy"
-import { IFilteringStrategy, FilteringStrategy } from "../../src/data-operations/filtering-strategy"
 import { FilteringCondition } from "../../src/data-operations/filtering-condition";
 import { FilteringLogic, IFilteringExpression } from "../../src/data-operations/filtering-expression.interface";
 import { IFilteringState } from "../../src/data-operations/filtering-state.interface";
+import { FilteringStrategy, IFilteringStrategy } from "../../src/data-operations/filtering-strategy";
+import { SortingStrategy } from "../../src/data-operations/sorting-strategy";
+import { StableSortingStrategy } from "../../src/data-operations/stable-sorting-strategy";
 
-const KEY_JOB_TITLE: String =  "JobTitle";
+const KEY_JOB_TITLE: string =  "JobTitle";
 
 export class CustomJobTitleSortingStrategy extends SortingStrategy {
-    jobTitles = {
+    public jobTitles = {
+        associateSoftwareDev : { name : "Associate Software Developer", weight : 8},
         ceo : { name: "CEO", weight: 1 },
-        vicePresident : { name: "Vice President", weight: 2 },
         director: { name: "Director", weight: 3 },
         manager : { name: "Manager", weight: 4 },
-        softwareDevTeamLead : { name: "Software Development Team Lead", weight: 5 },
         seniorSoftDev : { name: "Senior Software Developer", weight: 6 },
+        softwareDevTeamLead : { name: "Software Development Team Lead", weight: 5 },
         softwareDeveloper : { name : "Software Developer", weight: 7 },
-        associateSoftwareDev : { name : "Associate Software Developer", weight : 8}
+        vicePresident : { name: "Vice President", weight: 2 }
     };
 
+    protected compareObjects(obj1: object, obj2: object, key: string, reverse: number, ignoreCase: boolean): number {
+        let res;
+        if (key === KEY_JOB_TITLE) {
+            res = reverse * this.compareValues(this.getJobTitleWeight(obj1[key]),
+                                            this.getJobTitleWeight(obj2[key]));
+        } else {
+            res = super.compareObjects.apply(this, arguments);
+        }
+        const replacerFn = (replaceKey, val) => {
+            if (val === undefined) {
+                return null;
+            }
+            return val;
+        };
+        if (!res) {
+            return JSON.stringify(obj1, replacerFn)
+                .localeCompare(JSON.stringify(obj2, replacerFn));
+        }
+        return res;
+    }
     private getJobTitleWeight(value): number {
-        var weight = 0;
+        let weight = 0;
 
         switch (value) {
             case this.jobTitles.ceo.name:
@@ -53,28 +73,7 @@ export class CustomJobTitleSortingStrategy extends SortingStrategy {
         return weight;
     }
 
-    protected compareObjects(obj1: object, obj2: object, key: string, reverse: number, ignoreCase: boolean):number {
-        var res;
-        if (key === KEY_JOB_TITLE) {
-            res = reverse * this.compareValues(this.getJobTitleWeight(obj1[key]),
-                                            this.getJobTitleWeight(obj2[key]));
-        } else {
-            res = super.compareObjects.apply(this, arguments);
-        }
-        const replacerFn = (key, val) => {
-            if (val === undefined) {
-                return null;
-            }
-            return val;
-        };
-        if (!res) {
-            return JSON.stringify(obj1, replacerFn)
-                .localeCompare(JSON.stringify(obj2, replacerFn));
-        }
-        return res;
-    }
 }
-
 
 export class CustomDateRangeFilteringStrategy implements IFilteringStrategy {
     public filter<T>(data: T[],
@@ -98,7 +97,7 @@ export class CustomDateRangeFilteringStrategy implements IFilteringStrategy {
     public findMatch(rec: object, expr: IFilteringExpression, index: number): boolean {
         const cond = expr.condition;
         const val = rec[expr.fieldName];
-        var searchVal = "";
+        let searchVal = "";
 
         try {
             searchVal = JSON.parse(expr.searchVal);
@@ -108,9 +107,8 @@ export class CustomDateRangeFilteringStrategy implements IFilteringStrategy {
 
         if (typeof(searchVal) === "object" && Object.keys(searchVal).length === 2) {
             return (new Date(val) > new Date(searchVal[Object.keys(searchVal)[0]])) &&
-                (new Date(val) < new Date(searchVal[Object.keys(searchVal)[1]]))
-        }
-        else{
+                (new Date(val) < new Date(searchVal[Object.keys(searchVal)[1]]));
+        } else {
             return cond(new Date(val), new Date(searchVal));
         }
     }
@@ -138,7 +136,7 @@ export class CustomDateRangeFilteringStrategy implements IFilteringStrategy {
     }
 }
 
-export class CustomStrategyData{
+export class CustomStrategyData {
     public data = [
         { ID: 1, Name: "Casey Houston", JobTitle: "Vice President", HireDate: "2017-06-19T11:43:07.714Z" },
         { ID: 2, Name: "Gilberto Todd", JobTitle: "Director", HireDate: "2015-12-18T11:23:17.714Z" },
@@ -147,8 +145,12 @@ export class CustomStrategyData{
         { ID: 5, Name: "Celia Martinez", JobTitle: "Senior Software Developer", HireDate: "2007-12-19T11:23:17.714Z" },
         { ID: 6, Name: "Erma Walsh", JobTitle: "CEO", HireDate: "2016-12-18T11:23:17.714Z" },
         { ID: 7, Name: "Debra Morton", JobTitle: "Associate Software Developer", HireDate: "2005-11-19T11:23:17.714Z" },
-        { ID: 8, Name: "Erika Wells", JobTitle: "Software Development Team Lead", HireDate: "2005-10-14T11:23:17.714Z" },
-        { ID: 9, Name: "Leslie Hansen", JobTitle: "Associate Software Developer", HireDate: "2013-10-10T11:23:17.714Z" },
+        // tslint:disable-next-line:object-literal-sort-keys
+        { ID: 8, Name: "Erika Wells", JobTitle: "Software Development Team Lead",
+          HireDate: "2005-10-14T11:23:17.714Z" },
+        // tslint:disable-next-line:object-literal-sort-keys
+        { ID: 9, Name: "Leslie Hansen", JobTitle: "Associate Software Developer",
+          HireDate: "2013-10-10T11:23:17.714Z" },
         { ID: 10, Name: "Eduardo Ramirez", JobTitle: "Manager", HireDate: "2011-11-28T11:23:17.714Z" }
     ];
 }

--- a/src/grid/tests.helper.ts
+++ b/src/grid/tests.helper.ts
@@ -1,0 +1,72 @@
+import { SortingStrategy } from "../../src/data-operations/sorting-strategy"
+import { StableSortingStrategy } from "../../src/data-operations/stable-sorting-strategy"
+
+const KEY_JOB_TITLE: String =  "JobTitle";
+
+export class CustomJobTitleSortingStrategy extends SortingStrategy {
+    jobTitles = {
+        ceo : { name: "CEO", weight: 1 },
+        vicePresident : { name: "Vice President", weight: 2 },
+        director: { name: "Director", weight: 3 },
+        manager : { name: "Manager", weight: 4 },
+        softwareDevTeamLead : { name: "Software Development Team Lead", weight: 5 },
+        seniorSoftDev : { name: "Senior Software Developer", weight: 6 },
+        softwareDeveloper : { name : "Software Developer", weight: 7 },
+        associateSoftwareDev : { name : "Associate Software Developer", weight : 8}
+    };
+
+    private getJobTitleWeight(value): number {
+        var weight = 0;
+
+        switch (value) {
+            case this.jobTitles.ceo.name:
+                weight = this.jobTitles.ceo.weight;
+                break;
+            case this.jobTitles.vicePresident.name:
+                weight = this.jobTitles.vicePresident.weight;
+                break;
+            case this.jobTitles.director.name:
+                weight = this.jobTitles.director.weight;
+                break;
+            case this.jobTitles.manager.name:
+                weight = this.jobTitles.manager.weight;
+                break;
+            case this.jobTitles.softwareDevTeamLead.name:
+                weight = this.jobTitles.softwareDevTeamLead.weight;
+                break;
+            case this.jobTitles.seniorSoftDev.name:
+                weight = this.jobTitles.seniorSoftDev.weight;
+                break;
+            case this.jobTitles.softwareDeveloper.name:
+                weight = this.jobTitles.softwareDeveloper.weight;
+                break;
+            case this.jobTitles.associateSoftwareDev.name:
+                weight = this.jobTitles.associateSoftwareDev.weight;
+                break;
+            default:
+                break;
+        }
+        return weight;
+    }
+
+    protected compareObjects(obj1: object, obj2: object, key: string, reverse: number, ignoreCase: boolean):number {
+        var res;
+        if (key === KEY_JOB_TITLE) {
+            res = reverse * this.compareValues(this.getJobTitleWeight(obj1[key]),
+                                            this.getJobTitleWeight(obj2[key]));
+        } else {
+            res = super.compareObjects.apply(this, arguments);
+        }
+        const replacerFn = (key, val) => {
+            if (val === undefined) {
+                return null;
+            }
+            return val;
+        };
+        if (!res) {
+            return JSON.stringify(obj1, replacerFn)
+                .localeCompare(JSON.stringify(obj2, replacerFn));
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
Closes #397  .  
Scenarios that haven't been covered yet:

- Adding custom sorting strategy (job title sorting)
- Adding custom filtering strategy (using between filtering implementation)
- I bug was found #400 . After the bug is fixed second test should be included again (remove 'x' from 'it')

